### PR TITLE
Update postinstall.js

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -81,6 +81,9 @@ function sudoInstall() {
     )
   }
   //add CAN0 device
+  if (fs.existsSync("/etc/network/interfaces.d") == false)) {
+    execconfig(`mkdir -p /etc/network/interfaces.d`)  
+  }
   var can0 = fs.readdirSync("/etc/network/interfaces.d/")
   if (can0.includes("can0") == false) {
     execconfig(


### PR DESCRIPTION
/etc/network/interfaces.d may not yet exist, so let's create it. (happend with a stock install of the latest BBN)